### PR TITLE
Solution for issue # 1636 on Grapesjs project

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -19,7 +19,7 @@ define(function() {
       attributes: {class:'gjs-fonts gjs-f-b1'},
       content: `<table style="${tableStyleStr}">
         <tr>
-          <td style="${cellStyleStr}"></td>
+          <td style="${cellStyleStr} width: 100%"></td>
         </tr>
         </table>`,
     });


### PR DESCRIPTION
Hello @artf ,

This PR is to solve the bug reported in the following [issue on Grapesjs core project](https://github.com/artf/grapesjs/issues/1636).

I added a width to the 1 section block, to allow the user to add image blocks inside it on Safari.

This was tested on Chrome, Firefox and Safari.

Regards.